### PR TITLE
Initialize React layout and backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# chessies
+# Chessies
+
+A simple web-based chess game. The project uses a React frontend and a Flask
+backend. Currently it's just a skeleton to get development started.
+
+## Development
+
+### Frontend
+
+```
+cd frontend
+npm install        # install dependencies
+npm start          # run webpack dev server
+```
+
+### Backend
+
+```
+cd backend
+python app.py
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,15 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+game_state = {
+    "board": [],
+    "history": []
+}
+
+@app.route('/api/state')
+def get_state():
+    return jsonify(game_state)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chessies-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.9",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.0",
+    "babel-loader": "^9.1.3"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development --open",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chessies</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,11 @@
+.App {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}
+
+#board {
+  margin-bottom: 20px;
+  border: 1px solid #ccc;
+  height: 400px;
+  width: 400px;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import './App.css';
+
+function App() {
+  const [history, setHistory] = useState([]);
+
+  return (
+    <div className="App">
+      <h1>Chessies</h1>
+      <div id="board">Board will go here.</div>
+      <div id="history">
+        <h2>Move History</h2>
+        <ul>
+          {history.map((move, idx) => (
+            <li key={idx}>{move}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,37 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    port: 3000,
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+};


### PR DESCRIPTION
## Summary
- add basic React frontend with webpack build
- add Flask backend placeholder
- update README with dev instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c5b5faed083268bcc04310f03d596