### PR TITLE
Add missing Babel presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.0",
-    "babel-loader": "^9.1.3"
+    "babel-loader": "^9.1.3",
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-react": "^7.22.5"
   },
   "scripts": {
     "start": "webpack serve --mode development --open",


### PR DESCRIPTION
## Summary
- add `@babel/preset-env` and `@babel/preset-react` under `devDependencies`

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c615c29848326b30b0dd8f1850e38