### PR TITLE
Fix blank page by loading webpack bundle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,5 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load bundle.js in public/index.html so the React app renders

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c6742b7548326b2b90b8fbca6ab07