### PR TITLE
Fix stockfish engine loading

### DIFF
--- a/engine/createEngine.js
+++ b/engine/createEngine.js
@@ -1,0 +1,3 @@
+export default function createEngine() {
+  return new Worker(new URL('./stockfish-17-lite-single.js', import.meta.url));
+}

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 import { calculateValidMoves, setEnPassantInfo, getEnPassantInfo } from './movement.js';
-import createEngine from './engine/stockfish-17-lite-single.js';
+import createEngine from './engine/createEngine.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     let selectedPiece = null;


### PR DESCRIPTION
## Summary
- import engine via a wrapper module so it's loaded as a Worker
- create new helper `engine/createEngine.js`

## Testing
- `node -e "const sf=require('./engine/stockfish-17-lite-single.js'); console.log(typeof sf);"`

------
https://chatgpt.com/codex/tasks/task_b_684eb02e448883268d69ba8a563cdb27